### PR TITLE
Update to .net6

### DIFF
--- a/EurekaTrackerAutoPopper/EurekaTrackerAutoPopper.csproj
+++ b/EurekaTrackerAutoPopper/EurekaTrackerAutoPopper.csproj
@@ -1,102 +1,75 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
-  <PropertyGroup>
-    <Authors>electr0sheep</Authors>
-    <Company></Company>
-    <Version>0.0.0.2</Version>
-    <Description>XIV Launcher plugin for item vendors</Description>
-    <Copyright></Copyright>
-    <PackageProjectUrl></PackageProjectUrl>
-    <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
-    <Configurations>Debug;Release;DebugUI</Configurations>
-  </PropertyGroup>
+	<PropertyGroup>
+		<Authors>electr0sheep</Authors>
+		<Company></Company>
+		<Version>0.0.0.2</Version>
+		<Description>XIV Launcher plugin for item vendors</Description>
+		<Copyright></Copyright>
+		<PackageProjectUrl></PackageProjectUrl>
+		<CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
+		<Configurations>Debug;Release;DebugUI</Configurations>
+	</PropertyGroup>
 
-  <PropertyGroup>
-    <TargetFramework>net5.0-windows</TargetFramework>
-    <Platforms>x64</Platforms>
-    <Nullable>enable</Nullable>
-    <LangVersion>latest</LangVersion>
-    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <ProduceReferenceAssembly>false</ProduceReferenceAssembly>
-    <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
-    <OutputPath>bin\Debug\</OutputPath>
-  </PropertyGroup>
+	<PropertyGroup>
+		<TargetFramework>net6.0-windows</TargetFramework>
+		<Platforms>x64</Platforms>
+		<Nullable>enable</Nullable>
+		<LangVersion>latest</LangVersion>
+		<AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+		<ProduceReferenceAssembly>false</ProduceReferenceAssembly>
+		<AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
+		<OutputPath>bin\$(Configuration)\</OutputPath>
+		<RestorePackagesWithLockFile>true</RestorePackagesWithLockFile>
+	</PropertyGroup>
 
-  <ItemGroup>
-    <Content Include="..\EurekaTrackerAutoPopper\EurekaTrackerAutoPopper.json">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Content>
-  </ItemGroup>
+	<ItemGroup>
+		<Content Include="..\EurekaTrackerAutoPopper\EurekaTrackerAutoPopper.json">
+			<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+		</Content>
+	</ItemGroup>
 
-  <PropertyGroup>
-    <DalamudLibPath>$(appdata)\XIVLauncher\addon\Hooks\dev\</DalamudLibPath>
-  </PropertyGroup>
+	<PropertyGroup>
+		<DalamudLibPath>$(appdata)\XIVLauncher\addon\Hooks\dev\</DalamudLibPath>
+	</PropertyGroup>
 
-  <ItemGroup>
-    <None Include="..\.editorconfig" Link=".editorconfig" />
-  </ItemGroup>
+	<ItemGroup>
+		<None Include="..\.editorconfig" Link=".editorconfig" />
+	</ItemGroup>
 
-  <ItemGroup>
-    <PackageReference Include="Dalamud.DrunkenToad" Version="1.1.8" />
-    <PackageReference Include="DalamudPackager" Version="2.1.7" />
-    <PackageReference Include="ILRepack" Version="2.0.18" />
-    <PackageReference Include="XivCommon" Version="4.0.0" />
-    <Reference Include="FFXIVClientStructs">
-      <HintPath>$(DalamudLibPath)FFXIVClientStructs.dll</HintPath>
-      <Private>false</Private>
-    </Reference>
-    <Reference Include="Newtonsoft.Json">
-      <HintPath>$(DalamudLibPath)Newtonsoft.Json.dll</HintPath>
-      <Private>false</Private>
-    </Reference>
-    <Reference Include="Dalamud">
-      <HintPath>$(DalamudLibPath)Dalamud.dll</HintPath>
-      <Private>false</Private>
-    </Reference>
-    <Reference Include="ImGui.NET">
-      <HintPath>$(DalamudLibPath)ImGui.NET.dll</HintPath>
-      <Private>false</Private>
-    </Reference>
-    <Reference Include="ImGuiScene">
-      <HintPath>$(DalamudLibPath)ImGuiScene.dll</HintPath>
-      <Private>false</Private>
-    </Reference>
-    <Reference Include="Lumina">
-      <HintPath>$(DalamudLibPath)Lumina.dll</HintPath>
-      <Private>false</Private>
-    </Reference>
-    <Reference Include="Lumina.Excel">
-      <HintPath>$(DalamudLibPath)Lumina.Excel.dll</HintPath>
-      <Private>false</Private>
-    </Reference>
-  </ItemGroup>
-
-  <Target Name="MergeDeps" AfterTargets="Build">
-    <ItemGroup>
-      <InputAssemblies Include="$(TargetPath)" />
-      <InputAssemblies Include="$(TargetDir)*.dll" Exclude="$(TargetPath)" />
-      <DeleteFiles Include="$(TargetDir)*.dll" Exclude="$(TargetDir)$(TargetFileName)" />
-    </ItemGroup>
-    <Exec Command="$(PkgILRepack)\tools\ILRepack.exe /union /lib:$(DalamudLibPath) /out:$(TargetDir)$(TargetFileName) @(InputAssemblies, ' ')" />
-    <Delete Files="@(DeleteFiles)" />
-  </Target>
-
-  <Target Name="CopyToDevPlugins" AfterTargets="MergeDeps" Condition="'$(Configuration)' == 'Debug'">
-    <Exec Command="if not exist $(AppData)\XIVLauncher\devPlugins\$(TargetName) (mkdir $(AppData)\XIVLauncher\devPlugins\$(TargetName))" />
-    <Exec Command="copy $(TargetDir)$(TargetFileName) $(AppData)\XIVLauncher\devPlugins\$(TargetName)\$(TargetFileName)" />
-    <Exec Command="copy $(TargetDir)*.pdb $(AppData)\XIVLauncher\devPlugins\$(TargetName)" />
-  </Target>
-
-  <Target Name="Cleanup" AfterTargets="MergeDeps" Condition=" '$(Configuration)' == 'Release' ">
-    <ItemGroup>
-      <DeleteFiles Include="$(TargetDir)*.xml;$(TargetDir)*.json;$(TargetDir)*.pdb" />
-    </ItemGroup>
-    <Delete Files="@(DeleteFiles)" />
-  </Target>
-
-  <Target Name="CopyImages" AfterTargets="Package" Condition=" '$(Configuration)' == 'Release' ">
-    <MakeDir Directories="$(TargetDir)$(AssemblyName)\images" />
-    <Exec Command="copy $(ProjectDir)..\..\assets\*.png $(TargetDir)$(AssemblyName)\images\*.png" />
-  </Target>
+	<ItemGroup>
+		<PackageReference Include="Dalamud.DrunkenToad" Version="1.2.1" />
+		<PackageReference Include="DalamudPackager" Version="2.1.8" />
+		<PackageReference Include="ILRepack" Version="2.0.18" />
+		<PackageReference Include="XivCommon" Version="6.0.2" />
+		<Reference Include="FFXIVClientStructs">
+			<HintPath>$(DalamudLibPath)FFXIVClientStructs.dll</HintPath>
+			<Private>false</Private>
+		</Reference>
+		<Reference Include="Newtonsoft.Json">
+			<HintPath>$(DalamudLibPath)Newtonsoft.Json.dll</HintPath>
+			<Private>false</Private>
+		</Reference>
+		<Reference Include="Dalamud">
+			<HintPath>$(DalamudLibPath)Dalamud.dll</HintPath>
+			<Private>false</Private>
+		</Reference>
+		<Reference Include="ImGui.NET">
+			<HintPath>$(DalamudLibPath)ImGui.NET.dll</HintPath>
+			<Private>false</Private>
+		</Reference>
+		<Reference Include="ImGuiScene">
+			<HintPath>$(DalamudLibPath)ImGuiScene.dll</HintPath>
+			<Private>false</Private>
+		</Reference>
+		<Reference Include="Lumina">
+			<HintPath>$(DalamudLibPath)Lumina.dll</HintPath>
+			<Private>false</Private>
+		</Reference>
+		<Reference Include="Lumina.Excel">
+			<HintPath>$(DalamudLibPath)Lumina.Excel.dll</HintPath>
+			<Private>false</Private>
+		</Reference>
+	</ItemGroup>
 
 </Project>

--- a/EurekaTrackerAutoPopper/EurekaTrackerAutoPopper.json
+++ b/EurekaTrackerAutoPopper/EurekaTrackerAutoPopper.json
@@ -1,7 +1,5 @@
 {
-  "ApplicableVersion": "any",
   "Author": "electr0sheep",
-  "DalamudApiLevel": 6,
   "Description": "Automatically pops NMs in the Eureka Tracker",
   "InternalName": "eurekaTrackerAutoPopper",
   "Punchline":  "",

--- a/EurekaTrackerAutoPopper/EurekaTrackerWrapper/WebRequests.cs
+++ b/EurekaTrackerAutoPopper/EurekaTrackerWrapper/WebRequests.cs
@@ -4,17 +4,15 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Net;
+using System.Net.Http;
 using System.Net.WebSockets;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 
-namespace EurekaTrackerAutoPopper.EurekaTrackerWrapper
-{
-    internal class WebRequests
-    {
-        public static async void PopNM(ushort trackerId, string instance, string password)
-        {
+namespace EurekaTrackerAutoPopper.EurekaTrackerWrapper {
+    internal class WebRequests {
+        public static async void PopNM(ushort trackerId, string instance, string password) {
             ClientWebSocket socket = new();
             await socket.ConnectAsync(new Uri("wss://ffxiv-eureka.com/socket/websocket?vsn=2.0.0"), CancellationToken.None);
             await socket.SendAsync(Encoding.UTF8.GetBytes($"[\"1\",\"1\",\"instance:{instance}\",\"phx_join\",{{\"password\":\"{password}\"}}]"), WebSocketMessageType.Text, true, CancellationToken.None);
@@ -22,34 +20,33 @@ namespace EurekaTrackerAutoPopper.EurekaTrackerWrapper
             await socket.CloseAsync(WebSocketCloseStatus.NormalClosure, null, CancellationToken.None);
         }
 
-        public static (string instance, string response) CreateNewTracker(short trackerZoneId)
-        {
-            HttpWebRequest request = (HttpWebRequest)WebRequest.Create("https://ffxiv-eureka.com/api/instances");
-            request.Method = "POST";
-            request.Headers.Add("Content-Type:application/json");
-            request.GetRequestStream().Write(Encoding.UTF8.GetBytes($"{{\"data\":{{\"attributes\":{{\"zone-id\":\"{trackerZoneId}\"}},\"type\":\"instances\"}}}}"));
-            HttpWebResponse response = (HttpWebResponse)request.GetResponse();
-            if (response.StatusCode == HttpStatusCode.OK)
-            {
-                StreamReader reader = new(response.GetResponseStream());
-                string result = reader.ReadToEnd();
-                dynamic deserializedResult = JsonConvert.DeserializeObject(result)!;
-                string instance = deserializedResult.data.id;
-                string password = deserializedResult.data.attributes.password;
+        public static async Task<(string instance, string password)> CreateNewTracker(short trackerZoneId) {
+            HttpClient httpClient = new();
+            HttpResponseMessage response = await httpClient.PostAsync("https://ffxiv-eureka.com/api/instances",
+            new StringContent($"{{\"data\":{{\"attributes\":{{\"zone-id\":\"{trackerZoneId}\"}},\"type\":\"instances\"}}}}",
+            Encoding.UTF8, "application/json"));
+
+            httpClient.Dispose();
+
+            if (response.IsSuccessStatusCode) {
+                string result = await response.Content.ReadAsStringAsync();
+                dynamic jsonResult = JsonConvert.DeserializeObject(result)!;
+                string instance = jsonResult.data.id;
+                string password = jsonResult.data.attributes.password;
+
                 return (instance, password);
             }
+
             return ("", "");
         }
 
-        public static async Task<string?> FindTracker(uint dataCenterId, short zoneId)
-        {
+        public static async Task<string?> FindTracker(uint dataCenterId, short zoneId) {
             ClientWebSocket socket = new();
             try {
                 await socket.ConnectAsync(new Uri("wss://ffxiv-eureka.com/socket/websocket?vsn=2.0.0"), CancellationToken.None);
                 await socket.SendAsync(Encoding.UTF8.GetBytes($"[\"1\",\"1\",\"datacenter:{dataCenterId}\",\"phx_join\",{{}}]"), WebSocketMessageType.Text, true, CancellationToken.None);
             }
-            catch
-            {
+            catch {
                 return null;
             }
             byte[]? buffer = new byte[60000];
@@ -57,33 +54,27 @@ namespace EurekaTrackerAutoPopper.EurekaTrackerWrapper
             _ = await socket.ReceiveAsync(segment, CancellationToken.None);
             _ = await socket.ReceiveAsync(segment, CancellationToken.None);
             string result = Encoding.UTF8.GetString(buffer);
-            try
-            {
+            try {
                 dynamic deserializedResult = JsonConvert.DeserializeObject(result)!;
                 IEnumerable<dynamic> data = ((IEnumerable<dynamic>)deserializedResult[4].data).Where(i => i.relationships.zone.data.id == zoneId);
-                if (!data.Any())
-                {
+                if (!data.Any()) {
                     // SetupNewTracker(); let's not set up a new tracker by default for now
                     return null;
                 }
-                else
-                {
+                else {
                     string? instance = (string?)((Newtonsoft.Json.Linq.JValue)data.First().id).Value;
                     return instance ?? null;
                 }
             }
-            catch (JsonReaderException)
-            {
+            catch (JsonReaderException) {
                 return null;
             }
-            finally
-            {
+            finally {
                 await socket.CloseAsync(WebSocketCloseStatus.NormalClosure, null, CancellationToken.None);
             }
         }
 
-        private static long GetEpochTime()
-        {
+        private static long GetEpochTime() {
             return (long)(DateTime.UtcNow - new DateTime(1970, 1, 1)).TotalMilliseconds;
         }
     }

--- a/EurekaTrackerAutoPopper/PluginUI.cs
+++ b/EurekaTrackerAutoPopper/PluginUI.cs
@@ -4,6 +4,9 @@ using System.Numerics;
 using System.Diagnostics;
 using System.Threading.Tasks;
 using System.Collections.Generic;
+using Dalamud.Game.Text;
+using XivCommon.Functions;
+using Dalamud.Game.Text.SeStringHandling;
 
 namespace EurekaTrackerAutoPopper
 {
@@ -99,11 +102,11 @@ namespace EurekaTrackerAutoPopper
                 }
                 if (Plugin.PlayerInEureka && string.IsNullOrEmpty(instance) && ImGui.Button("Start New Tracker"))
                 {
-                    Task.Run(() =>
+                    Task.Run(async () =>
                     {
                         bool previousSoundEffectSetting = playSoundEffect;
                         bool previousEchoNMPopSetting = echoNMPop;
-                        (instance, password) = EurekaTrackerWrapper.WebRequests.CreateNewTracker(Library.TerritoryToTrackerDictionary[Plugin.ClientState.TerritoryType]);
+                        (instance, password) = await EurekaTrackerWrapper.WebRequests.CreateNewTracker(Library.TerritoryToTrackerDictionary[Plugin.ClientState.TerritoryType]);
                         playSoundEffect = false;
                         echoNMPop = false;
                         Plugin.ProcessCurrentFates(Plugin.ClientState.TerritoryType);

--- a/EurekaTrackerAutoPopper/packages.lock.json
+++ b/EurekaTrackerAutoPopper/packages.lock.json
@@ -1,0 +1,39 @@
+{
+  "version": 1,
+  "dependencies": {
+    "net6.0-windows7.0": {
+      "Dalamud.DrunkenToad": {
+        "type": "Direct",
+        "requested": "[1.2.1, )",
+        "resolved": "1.2.1",
+        "contentHash": "kwub5Fwbtp88S+/y5Ce7fXzHGOz7ARKiu8mWbtonjRKqegOGObowUJoGZKPFDE2iTeDta8lDtNl/L5xaB9JCDw==",
+        "dependencies": {
+          "LiteDB": "5.0.11"
+        }
+      },
+      "DalamudPackager": {
+        "type": "Direct",
+        "requested": "[2.1.8, )",
+        "resolved": "2.1.8",
+        "contentHash": "YqagNXs9InxmqkXzq7kLveImxnodkBEicAhydMXVp7dFjC7xb76U6zGgAax4/BWIWfZeWzr5DJyQSev31kj81A=="
+      },
+      "ILRepack": {
+        "type": "Direct",
+        "requested": "[2.0.18, )",
+        "resolved": "2.0.18",
+        "contentHash": "sR5Aj3JLDbA8JwESfWYfigSz5k1oNSHPN434W1LX8sboWJYEOSQP/KkvZGmJKPgajzSUKkl2jDar3LPZiMFU4Q=="
+      },
+      "XivCommon": {
+        "type": "Direct",
+        "requested": "[6.0.2, )",
+        "resolved": "6.0.2",
+        "contentHash": "C/GnQ61iO0yEpf8LPixU3tCThar1MWUiBkO8gdZHNtVskg8AvFeuIxk7Zmkf2yeAJ0drR/KOTdSS7GpbsgmoaQ=="
+      },
+      "LiteDB": {
+        "type": "Transitive",
+        "resolved": "5.0.11",
+        "contentHash": "6cL4bOmVCUB0gIK+6qIr68HeqjjHZicPDGQjvJ87mIOvkFsEsJWkIps3yoKNeLpHhJQur++yoQ9Q8gxsdos0xQ=="
+      }
+    }
+  }
+}

--- a/UIDev/UIDev.csproj
+++ b/UIDev/UIDev.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net5.0-windows</TargetFramework>
+    <TargetFramework>net6.0-windows</TargetFramework>
     <Platforms>x64</Platforms>
     <Nullable>enable</Nullable>
     <OutputType>WinExe</OutputType>


### PR DESCRIPTION
Update the plugin to run on .net6, also removes the `DalamudApiLevel` since its not needed anymore because `DalamudPackager` controls the API Level, so in case a bump is needed, `DalamudPackager` should be updated.