### PR TITLE
add option to show pot timer on server info bar

### DIFF
--- a/EurekaTrackerAutoPopper/Configuration.cs
+++ b/EurekaTrackerAutoPopper/Configuration.cs
@@ -1,4 +1,4 @@
-﻿using Dalamud.Configuration;
+using Dalamud.Configuration;
 using System;
 using System.Collections.Generic;
 using System.Numerics;
@@ -65,6 +65,8 @@ public class Configuration : IPluginConfiguration
 
     public bool UploadNotification = true;
     public bool UploadPermission = true;
+
+    public bool ShowPotDtrBar = true;
 
     public long TimeInEureka = 0;  // in milliseconds
     public int KilledBunnies = 0;

--- a/EurekaTrackerAutoPopper/Plugin.cs
+++ b/EurekaTrackerAutoPopper/Plugin.cs
@@ -366,6 +366,8 @@ public class Plugin : IDalamudPlugin
             Framework.Update -= OccultPotCheck;
             Framework.Update -= UpdateDtr;
 
+            PotDtrBar.Hide();
+
             Fates.RemoveEvents();
         }
     }

--- a/EurekaTrackerAutoPopper/Plugin.cs
+++ b/EurekaTrackerAutoPopper/Plugin.cs
@@ -101,7 +101,7 @@ public class Plugin : IDalamudPlugin
 
         Fates = new Fates(this);
         TrackerHandler = new TrackerHandler(this);
-        PotDtrBar = new PotDtrBar(this, DtrBar);
+        PotDtrBar = new PotDtrBar(this);
 
         MainWindow = new MainWindow(this);
         OccultWindow = new OccultWindow(this);

--- a/EurekaTrackerAutoPopper/PotDtrBar.cs
+++ b/EurekaTrackerAutoPopper/PotDtrBar.cs
@@ -35,6 +35,12 @@ public class PotDtrBar : IDisposable
         }
     }
 
+    public void Hide()
+    {
+        if (DtrEntry != null)
+            DtrEntry.Shown = false;
+    }
+
     public void Update()
     {
         if (DtrEntry == null)

--- a/EurekaTrackerAutoPopper/PotDtrBar.cs
+++ b/EurekaTrackerAutoPopper/PotDtrBar.cs
@@ -1,0 +1,94 @@
+using System;
+using System.Linq;
+using Dalamud.Game.Gui.Dtr;
+using Dalamud.Game.Text.SeStringHandling;
+using Dalamud.Plugin.Services;
+
+namespace EurekaTrackerAutoPopper;
+
+public class PotDtrBar : IDisposable
+{
+    private const int OccultRespawn = 1805;
+
+    private readonly Plugin Plugin;
+    private readonly IDtrBar DtrBar;
+    private readonly IDtrBarEntry? DtrEntry;
+
+    public PotDtrBar(Plugin plugin, IDtrBar dtrBar)
+    {
+        Plugin = plugin;
+        DtrBar = dtrBar;
+
+        DtrEntry = DtrBar.Get("Eureka Linker Pot Timer");
+        if (DtrEntry != null)
+        {
+            DtrEntry.OnClick += OnClick;
+        }
+    }
+
+    public void Dispose()
+    {
+        if (DtrEntry != null)
+        {
+            DtrEntry.OnClick -= OnClick;
+            DtrEntry.Remove();
+        }
+    }
+
+    public void Update()
+    {
+        if (DtrEntry == null)
+            return;
+
+        if (!Plugin.Configuration.ShowPotDtrBar || !Plugin.PlayerInOccultTerritory())
+        {
+            DtrEntry.Shown = false;
+            return;
+        }
+
+        var potInfo = Plugin.BunnyWindow.GetOccultPotInfo();
+        if (potInfo == null)
+        {
+            DtrEntry.Shown = false;
+            return;
+        }
+
+        var (displayFate, lastFate) = potInfo.Value;
+
+        if (displayFate.Alive)
+        {
+            var activeFateDirection = displayFate.FateId == 1976 ? "North" : "South";
+            DtrEntry.Text = new SeString(new Dalamud.Game.Text.SeStringHandling.Payloads.TextPayload($"Pot: Active ({activeFateDirection})"));
+            DtrEntry.Shown = true;
+            return;
+        }
+
+        if (displayFate.LastSeenAlive == -1)
+        {
+            DtrEntry.Shown = false;
+            return;
+        }
+
+        var currentTime = DateTimeOffset.UtcNow.ToUnixTimeSeconds();
+        var respawnTime = TimeSpan.FromSeconds(lastFate.SpawnTime + OccultRespawn - currentTime);
+
+        if (respawnTime.TotalSeconds < 0)
+            respawnTime = TimeSpan.Zero;
+
+        var direction = displayFate.FateId == 1976 ? "North" : "South";
+        var timeString = Utils.TimeToClockFormat(respawnTime);
+
+        DtrEntry.Text = new SeString(new Dalamud.Game.Text.SeStringHandling.Payloads.TextPayload($"Next pot: {timeString} ({direction})"));
+        DtrEntry.Shown = true;
+    }
+
+    private void OnClick(DtrInteractionEvent e)
+    {
+        var potInfo = Plugin.BunnyWindow.GetOccultPotInfo();
+        if (potInfo == null)
+            return;
+
+        var (displayFate, _) = potInfo.Value;
+        Plugin.OpenMap(displayFate.MapLinkPayload);
+    }
+}

--- a/EurekaTrackerAutoPopper/PotDtrBar.cs
+++ b/EurekaTrackerAutoPopper/PotDtrBar.cs
@@ -1,8 +1,5 @@
 using System;
-using System.Linq;
 using Dalamud.Game.Gui.Dtr;
-using Dalamud.Game.Text.SeStringHandling;
-using Dalamud.Plugin.Services;
 
 namespace EurekaTrackerAutoPopper;
 
@@ -11,18 +8,17 @@ public class PotDtrBar : IDisposable
     private const int OccultRespawn = 1805;
 
     private readonly Plugin Plugin;
-    private readonly IDtrBar DtrBar;
     private readonly IDtrBarEntry? DtrEntry;
 
-    public PotDtrBar(Plugin plugin, IDtrBar dtrBar)
+    public PotDtrBar(Plugin plugin)
     {
         Plugin = plugin;
-        DtrBar = dtrBar;
 
-        DtrEntry = DtrBar.Get("Eureka Linker Pot Timer");
+        DtrEntry = Plugin.DtrBar.Get("Eureka Linker Pot Timer");
         if (DtrEntry != null)
         {
             DtrEntry.OnClick += OnClick;
+            DtrEntry.Tooltip = "Eureka Linker\nClick to place flag on map\n\nDisable in: /el - Occult - Pot - Show Timer On Server Info Bar";
         }
     }
 
@@ -64,7 +60,7 @@ public class PotDtrBar : IDisposable
         if (displayFate.Alive)
         {
             var activeFateDirection = displayFate.FateId == 1976 ? "North" : "South";
-            DtrEntry.Text = new SeString(new Dalamud.Game.Text.SeStringHandling.Payloads.TextPayload($"Pot: Active ({activeFateDirection})"));
+            DtrEntry.Text = $"Pot: Active ({activeFateDirection})";
             DtrEntry.Shown = true;
             return;
         }
@@ -84,7 +80,7 @@ public class PotDtrBar : IDisposable
         var direction = displayFate.FateId == 1976 ? "North" : "South";
         var timeString = Utils.TimeToClockFormat(respawnTime);
 
-        DtrEntry.Text = new SeString(new Dalamud.Game.Text.SeStringHandling.Payloads.TextPayload($"Next pot: {timeString} ({direction})"));
+        DtrEntry.Text = $"Next pot: {timeString} ({direction})";
         DtrEntry.Shown = true;
     }
 

--- a/EurekaTrackerAutoPopper/Windows/MainWindow/MainWindow.Occult.cs
+++ b/EurekaTrackerAutoPopper/Windows/MainWindow/MainWindow.Occult.cs
@@ -184,6 +184,9 @@ public partial class MainWindow
                 changed |= ImGui.Checkbox(Language.ConfigOptionAutoPots, ref Plugin.Configuration.AutoSwitchToOccultPots);
                 ImGuiComponents.HelpMarker(Language.ConfigTooltipAutoPots);
 
+                changed |= ImGui.Checkbox("Show Timer On Server Info Bar", ref Plugin.Configuration.ShowPotDtrBar);
+                ImGuiComponents.HelpMarker("Display the pot FATE timer in the server info bar. Click the timer to place a flag on the map.");
+
                 if (changed)
                     Plugin.Configuration.Save();
             }

--- a/EurekaTrackerAutoPopper/Windows/Overlay/BunnyWindow.cs
+++ b/EurekaTrackerAutoPopper/Windows/Overlay/BunnyWindow.cs
@@ -44,6 +44,40 @@ public class BunnyWindow : Window, IDisposable
         return InEureka || InOccult;
     }
 
+    public (Fate displayFate, Fate lastFate)? GetOccultPotInfo()
+    {
+        if (!InOccult)
+            return null;
+
+        var bunnies = Plugin.Fates.BunnyFates.Where(bnuuuy => (uint)bnuuuy.Territory == Plugin.ClientState.TerritoryType).ToArray();
+        if (bunnies.Length == 0)
+            return null;
+
+        var sortedFates = bunnies.OrderBy(bnuuuy => bnuuuy.LastSeenAlive).ToArray();
+        var nextSpawn = sortedFates[0];
+        var lastAlive = sortedFates[^1];
+
+        // If it is -1 there hasn't been any pop yet
+        if (nextSpawn.LastSeenAlive == -1 && lastAlive.LastSeenAlive == -1)
+        {
+            return (nextSpawn, nextSpawn);
+        }
+        // If our last alive is still active then show it
+        else if (lastAlive.Alive)
+        {
+            return (lastAlive, lastAlive);
+        }
+        // Apply the time of latest spawn to calculate next respawn
+        else
+        {
+            // Set LastSeenAlive to 30min previously
+            if (nextSpawn.LastSeenAlive == -1)
+                nextSpawn.LastSeenAlive = lastAlive.SpawnTime - OccultRespawn;
+
+            return (nextSpawn, lastAlive);
+        }
+    }
+
     public override void Draw()
     {
         var bunnies = Plugin.Fates.BunnyFates.Where(bnuuuy => (uint)bnuuuy.Territory == Plugin.ClientState.TerritoryType).ToArray();


### PR DESCRIPTION
This adds a new option to show the pot timer on the Server Info Bar.
<img width="165" height="38" alt="image" src="https://github.com/user-attachments/assets/6bc1a590-666e-42af-ba49-c5a37c0d3dde" />

- Visibility can be changed in the settings tab
<img width="804" height="299" alt="image" src="https://github.com/user-attachments/assets/c76f0914-2032-48d5-8a6d-6fffc4746e33" />
- Clicking the entry places the flag on the map for the associated pot fate
- Timer does not show if the time is unknown